### PR TITLE
fix(nimble datatable): fix column responsiveness when there is a long…

### DIFF
--- a/src/components/nimbleDataTable/StyledWrappers.tsx
+++ b/src/components/nimbleDataTable/StyledWrappers.tsx
@@ -143,6 +143,7 @@ const TableValue = styled(Typography)(({fontFamily, fontSize}: TableValueProps) 
   color: '#222222',
   minHeight: '44px',
   alignItems: 'center',
+  wordBreak: 'break-all',
 }));
 
 const ActionCell = styled('td')({


### PR DESCRIPTION
If a word is too long, it'll break to keep the responsiveness of the data table

fix #146
<img width="1045" alt="Screenshot 2023-10-11 at 7 12 53 AM" src="https://github.com/Nimble-Institute/nimble-design-system/assets/23234889/e30c68c6-b0f9-4f23-8a5f-ade841b013dc">
