### PR TITLE
fix(nimble autocomplete): autocomplete search behind chip

### DIFF
--- a/src/components/nimbleAutoComplete/NimbleAutoComplete.tsx
+++ b/src/components/nimbleAutoComplete/NimbleAutoComplete.tsx
@@ -85,7 +85,7 @@ export const NimbleAutoComplete: React.FC<NimbleAutoCompleteProps> = ({
 
   const renderTags = (value: any, getTagProps: any) => {
     return (
-      <TagWrapper>
+      <>
         {value.map((option: any, index: number) => (
           <TagChip
             variant="filled"
@@ -97,7 +97,7 @@ export const NimbleAutoComplete: React.FC<NimbleAutoCompleteProps> = ({
             fontFamily={fontFamily}
           />
         ))}
-      </TagWrapper>
+      </>
     );
   };
 

--- a/src/components/nimbleAutoComplete/StyledWrappers.tsx
+++ b/src/components/nimbleAutoComplete/StyledWrappers.tsx
@@ -18,11 +18,6 @@ interface SlectedIconProps {
   chipcolor: string;
 }
 
-const TagWrapper = styled('div')({
-  maxHeight: '100px',
-  overflow: 'auto',
-});
-
 const TagChip = styled(Chip)(({chipcolor, fontFamily}: TagProps) => ({
   backgroundColor: chipcolor,
   color: '#fff',
@@ -57,7 +52,6 @@ const OptionLabel = styled(Typography)(({fontFamily}: OptionLabelProps) => ({
   fontFamily: fontFamily,
   color: '#0C1B2A',
   lineHeight: '20px',
-  // padding: '6px 4px',
   width: '100%',
 }));
 
@@ -67,7 +61,8 @@ const SlectedIcon = styled(CheckCircleOutlineIcon)(({chipcolor}: SlectedIconProp
 }));
 
 const TextInput = styled(TextField)(({fontFamily}: TextInputProps) => ({
+  '& input': {minWidth: '75px !important'},
   '& input::placeholder': {fontSize: '14px', fontFamily: fontFamily},
 }));
 
-export {TagWrapper, TagChip, OptionList, OptionLabel, SlectedIcon, TextInput};
+export {TagChip, OptionList, OptionLabel, SlectedIcon, TextInput};


### PR DESCRIPTION

Autocomplete search behind chip when enough space left
<img width="611" alt="Screenshot 2023-10-12 at 10 47 44 AM" src="https://github.com/Nimble-Institute/nimble-design-system/assets/23234889/1181b6bf-2035-4d29-9900-018c72ff38be">

fix #72