### PR TITLE
fix(nimbledatagrid): fix rendering 0 when there's no data for the grid

### DIFF
--- a/src/components/nimbleDataGrid/NimbleDataGrid.tsx
+++ b/src/components/nimbleDataGrid/NimbleDataGrid.tsx
@@ -163,12 +163,13 @@ export const NimbleDataGrid: React.FC<NimbleDataGridProps> = ({
           </Collapse>
         </TopWrapper>
         <DataWrapper>
-          {data.length &&
-            data.map((item, index) => (
-              <Item key={index} elevation={0} onClick={() => onClickDataCard && onClickDataCard(item)}>
-                {renderCard(item)}
-              </Item>
-            ))}
+          {data.length
+            ? data.map((item, index) => (
+                <Item key={index} elevation={0} onClick={() => onClickDataCard && onClickDataCard(item)}>
+                  {renderCard(item)}
+                </Item>
+              ))
+            : null}
         </DataWrapper>
         <FooterWrapper>
           <PaginationBar


### PR DESCRIPTION
fix #288